### PR TITLE
ci: Add conventional-commit-title check action to workflows

### DIFF
--- a/.github/workflows/validate-conventional-commits.yaml
+++ b/.github/workflows/validate-conventional-commits.yaml
@@ -1,0 +1,22 @@
+name: PR Conventional Commit Validation
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Conventional Commit Validation
+        uses:  ytanikin/pr-conventional-commits@8267db1bacc237419f9ed0228bb9d94e94271a1d # v1.4.1
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'


### PR DESCRIPTION
## Description

Adds a conventional commit validation workflow

## Related Issue(s)

Fixes #39 