### PR TITLE
feat(projects): Add projects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,13 @@ FIREBASE_PROJECT_ID=paintbar-7f887
 # Path to Firebase service account JSON (required for preview/production)
 FIREBASE_SERVICE_ACCOUNT_PATH=./firebase-service-account.json
 
+# Firebase Storage bucket name
+FIREBASE_STORAGE_BUCKET=paintbar-7f887.firebasestorage.app
+
 # Firebase emulator hosts (auto-configured for local, leave empty for preview/prod)
 FIRESTORE_EMULATOR_HOST=localhost:8081
 FIREBASE_AUTH_EMULATOR_HOST=localhost:9099
+FIREBASE_STORAGE_EMULATOR_HOST=localhost:9199
 
 # Hiero network: local, testnet, mainnet
 HIERO_NETWORK=local

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Compiled binaries
+server
+
 # Dependencies
 node_modules/
 firebase-debug.log*

--- a/Dockerfile.firebase
+++ b/Dockerfile.firebase
@@ -6,18 +6,18 @@ RUN npm install -g firebase-tools
 
 WORKDIR /app
 
-# Create firebase.json for emulator config
-RUN echo '{ \
-  "emulators": { \
-    "auth": { "port": 9099, "host": "0.0.0.0" }, \
-    "firestore": { "port": 8080, "host": "0.0.0.0" }, \
-    "ui": { "enabled": true, "port": 4000, "host": "0.0.0.0" } \
-  }, \
-  "firestore": { \
-    "rules": "firestore.rules" \
-  } \
-}' > firebase.json
+# Create firebase.json for emulator config (storage emulator included)
+RUN printf '{\n\
+  "emulators": {\n\
+    "auth": { "port": 9099, "host": "0.0.0.0" },\n\
+    "firestore": { "port": 8080, "host": "0.0.0.0" },\n\
+    "storage": { "port": 9199, "host": "0.0.0.0" },\n\
+    "ui": { "enabled": true, "port": 4000, "host": "0.0.0.0" }\n\
+  },\n\
+  "firestore": { "rules": "firestore.rules" },\n\
+  "storage": { "rules": "storage.rules" }\n\
+}\n' > firebase.json
 
-EXPOSE 4000 8080 9099
+EXPOSE 4000 8080 9099 9199
 
 CMD ["firebase", "emulators:start", "--project", "paintbar-7f887", "--import", "/app/testdata", "--export-on-exit", "/app/testdata"]

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -155,8 +155,13 @@ paths:
           $ref: "#/components/responses/Unauthorized"
     post:
       tags: [Projects]
-      summary: Create a new project
+      summary: Create or upsert a project
       operationId: createProject
+      description: |
+        Creates a new project or upserts an existing one. Titles are unique per user.
+        - If a project with the same contentHash exists: returns Duplicate=true, no upload.
+        - If a project with the same title exists: updates its content (upsert), returns upload URL.
+        - Otherwise: creates a new project.
       requestBody:
         required: true
         content:
@@ -165,11 +170,50 @@ paths:
               $ref: "#/components/schemas/ProjectCreate"
       responses:
         "201":
-          $ref: "#/components/responses/Created"
+          description: Project created/upserted with optional upload URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateProjectResult"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "409":
+          description: Duplicate content hash (returns existing project)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateProjectResult"
+
+  /api/projects/by-title:
+    get:
+      tags: [Projects]
+      summary: Get a project by title
+      operationId: getProjectByTitle
+      description: Looks up a project by title for the authenticated user. Titles are unique per user.
+      parameters:
+        - name: title
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Project title to look up
+      responses:
+        "200":
+          description: Project details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /api/projects/count:
     get:
@@ -234,6 +278,57 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/Deleted"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/projects/{id}/confirm-upload:
+    post:
+      tags: [Projects]
+      summary: Confirm blob upload to Storage
+      operationId: confirmUpload
+      description: |
+        Called by the client after successfully uploading the PNG blob
+        to the signed URL. Verifies the object exists in Storage and
+        sets the storageURL on the project record.
+      parameters:
+        - $ref: "#/components/parameters/ResourceID"
+      responses:
+        "200":
+          $ref: "#/components/responses/StatusOK"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  /api/projects/{id}/blob:
+    get:
+      tags: [Projects]
+      summary: Download project PNG blob
+      operationId: downloadBlob
+      description: |
+        Streams the project's full-resolution PNG from Storage through the API.
+        This avoids CORS issues with direct Storage/emulator URLs.
+        Response has Cache-Control: no-store to ensure fresh content after upserts.
+      parameters:
+        - $ref: "#/components/parameters/ResourceID"
+      responses:
+        "200":
+          description: PNG image blob
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -521,18 +616,22 @@ components:
           type: string
         userId:
           type: string
-        name:
+        title:
           type: string
           maxLength: 200
-        description:
+        contentHash:
           type: string
-          maxLength: 2000
-        imageData:
+          description: SHA-256 hex digest of the canvas PNG blob (64 chars)
+          pattern: "^[0-9a-f]{64}$"
+        storageURL:
           type: string
-          description: Base64-encoded canvas image data
+          description: Firebase Storage download URL for the full-resolution PNG
         thumbnailData:
           type: string
-          description: Base64-encoded thumbnail
+          maxLength: 512000
+          description: |
+            Base64-encoded data:image/ URI thumbnail (longest edge 200px, aspect ratio preserved).
+            Must start with "data:image/" prefix. Maximum 500 KB.
         width:
           type: integer
         height:
@@ -554,18 +653,19 @@ components:
 
     ProjectCreate:
       type: object
-      required: [name]
+      required: [title, contentHash, thumbnailData, width, height]
       properties:
-        name:
+        title:
           type: string
           maxLength: 200
-        description:
+        contentHash:
           type: string
-          maxLength: 2000
-        imageData:
-          type: string
+          description: SHA-256 hex digest of the canvas PNG blob
+          pattern: "^[0-9a-f]{64}$"
         thumbnailData:
           type: string
+          maxLength: 512000
+          description: Base64-encoded data:image/ URI thumbnail (max 500 KB)
         width:
           type: integer
         height:
@@ -578,30 +678,35 @@ components:
           items:
             type: string
 
+    CreateProjectResult:
+      type: object
+      required: [projectId, duplicate]
+      properties:
+        projectId:
+          type: string
+          description: The Firestore document ID of the project
+        uploadURL:
+          type: string
+          description: Signed URL for PUT upload of the PNG blob (omitted for duplicates)
+        duplicate:
+          type: boolean
+          description: True if a project with the same contentHash already exists for this user
+
     ProjectUpdate:
       type: object
-      description: Partial update — only provided fields are changed
+      description: Partial update — only provided fields are changed. Title, isPublic, and tags are the only mutable fields.
       properties:
-        name:
+        title:
           type: string
           maxLength: 200
-        description:
-          type: string
-          maxLength: 2000
-        imageData:
-          type: string
-        thumbnailData:
-          type: string
-        width:
-          type: integer
-        height:
-          type: integer
         isPublic:
           type: boolean
         tags:
           type: array
+          maxItems: 20
           items:
             type: string
+            maxLength: 50
 
     GalleryItem:
       type: object
@@ -620,8 +725,12 @@ components:
           maxLength: 2000
         imageData:
           type: string
+          maxLength: 512000
+          description: Base64-encoded image data (max 500 KB)
         thumbnailData:
           type: string
+          maxLength: 512000
+          description: Base64-encoded data:image/ URI thumbnail (max 500 KB)
         width:
           type: integer
         height:
@@ -673,11 +782,16 @@ components:
           type: string
         imageData:
           type: string
+          maxLength: 512000
+          description: Base64-encoded image data (max 500 KB)
         imageUrl:
           type: string
           format: uri
+          description: Image URL (must use http or https scheme)
         thumbnailData:
           type: string
+          maxLength: 512000
+          description: Base64-encoded data:image/ URI thumbnail (max 500 KB)
         metadata:
           type: string
         price:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - FIREBASE_PROJECT_ID=paintbar-7f887
       - FIRESTORE_EMULATOR_HOST=firebase:8080
       - FIREBASE_AUTH_EMULATOR_HOST=firebase:9099
+      - FIREBASE_STORAGE_EMULATOR_HOST=firebase:9199
+      - FIREBASE_STORAGE_BUCKET=paintbar-7f887.firebasestorage.app
       - HIERO_NETWORK=local
     depends_on:
       firebase:
@@ -26,10 +28,12 @@ services:
       - "4000:4000"   # Emulator UI
       - "9099:9099"   # Auth emulator
       - "8081:8080"   # Firestore emulator (mapped to 8081 on host to avoid conflict)
+      - "9199:9199"   # Storage emulator
     volumes:
       - ./testdata/firestore:/app/testdata
       - ./firestore.rules:/app/firestore.rules:ro
       - ./firestore.indexes.json:/app/firestore.indexes.json:ro
+      - ./storage.rules:/app/storage.rules:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:4000 || exit 1"]
       interval: 5s

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -80,10 +80,10 @@ User's saved drawing projects from the canvas.
 | Field           | Type      | Required | Description                                  |
 | --------------- | --------- | -------- | -------------------------------------------- |
 | `userId`        | string    | Yes      | Owner's Firebase Auth UID                    |
-| `name`          | string    | Yes      | Project name                                 |
-| `description`   | string    | No       | Project description                          |
-| `imageData`     | string    | Yes      | Canvas image data (base64 or URL)            |
-| `thumbnailData` | string    | No       | Thumbnail for grid display                   |
+| `title`         | string    | Yes      | Project title                                |
+| `contentHash`   | string    | Yes      | SHA-256 hex of canvas PNG (64 chars)         |
+| `storageURL`    | string    | No       | Firebase Storage download URL                |
+| `thumbnailData` | string    | No       | Thumbnail for grid display (200px max edge)  |
 | `width`         | number    | Yes      | Canvas width in pixels                       |
 | `height`        | number    | Yes      | Canvas height in pixels                      |
 | `isPublic`      | boolean   | No       | Whether project is visible in public gallery |

--- a/docs/database.md
+++ b/docs/database.md
@@ -24,26 +24,25 @@ is handled in-memory by the Go middleware.
 │  │  website     │◄──────────▶│  projects    │                          │
 │  │  githubUrl   │            │              │                          │
 │  │  twitterHdl  │            │  id (auto)   │                          │
-│  │  blueskyHdl  │            │  userId      │──┐                      │
-│  │  instagramHdl│            │  name        │  │                      │
-│  │  hbarAddress │            │  description │  │  1:N                  │
-│  │  createdAt   │            │  imageData   │  │  (via projectId)     │
-│  │  updatedAt   │            │  thumbnailDt │  │  ┌──────────────┐    │
-│  └──────────────┘            │  width       │  └─▶│  gallery     │    │
+│  │  instagramHdl│            │  userId      │──┐                      │
+│  │  hbarAddress │            │  title       │  │                      │
+│  │  createdAt   │            │  contentHash │  │  1:N                  │
+│  │  updatedAt   │            │  storageURL  │  │  (via projectId)     │
+│  └──────────────┘            │  thumbnailDt │  │  ┌──────────────┐    │
+│         │                    │  width       │  └─▶│  gallery     │    │
 │         │                    │  height      │     │              │    │
 │         │                    │  isPublic    │     │  id (auto)   │    │
 │         │                    │  tags[]      │     │  userId      │    │
 │         │                    │  createdAt   │     │  projectId   │    │
-│         │                    │  updatedAt   │     │  name        │    │
-│         │                    └──────────────┘     │  description │    │
-│         │                                         │  imageData   │    │
-│         │    1:N     ┌──────────────┐             │  thumbnailDt │    │
-│         └───────────▶│    nfts      │             │  width       │    │
-│                      │              │             │  height      │    │
-│                      │  id (auto)   │             │  tags[]      │    │
-│                      │  userId      │             │  createdAt   │    │
-│                      │  name        │             └──────────────┘    │
-│                      │  description │                                  │
+│         │                    └──────────────┘     │  name        │    │
+│         │                                         │  description │    │
+│         │    1:N     ┌──────────────┐             │  imageData   │    │
+│         └───────────▶│    nfts      │             │  thumbnailDt │    │
+│                      │              │             │  width       │    │
+│                      │  id (auto)   │             │  height      │    │
+│                      │  userId      │             │  tags[]      │    │
+│                      │  name        │             │  createdAt   │    │
+│                      │  description │             └──────────────┘    │
 │                      │  imageData   │                                  │
 │                      │  imageUrl    │                                  │
 │                      │  thumbnailDt │                                  │
@@ -103,19 +102,19 @@ Lookup collection for username uniqueness enforcement. Keyed by the username str
 
 Canvas projects. Auto-generated document IDs.
 
-| Field           | Type            | Required | Description                              |
-| --------------- | --------------- | -------- | ---------------------------------------- |
-| `userId`        | string          | ✅       | Owner's Firebase Auth UID                |
-| `name`          | string          | ✅       | Project name (max 200 chars)             |
-| `description`   | string          |          | Description (max 2000 chars)             |
-| `imageData`     | string          |          | Base64-encoded canvas image              |
-| `thumbnailData` | string          |          | Base64-encoded thumbnail                 |
-| `width`         | integer         |          | Canvas width in pixels                   |
-| `height`        | integer         |          | Canvas height in pixels                  |
-| `isPublic`      | boolean         |          | Public visibility flag (default `false`) |
-| `tags`          | array\<string\> |          | Tags (max 20, each max 50 chars)         |
-| `createdAt`     | timestamp       | ✅       | Creation timestamp                       |
-| `updatedAt`     | timestamp       | ✅       | Last update timestamp                    |
+| Field           | Type            | Required | Description                                    |
+| --------------- | --------------- | -------- | ---------------------------------------------- |
+| `userId`        | string          | ✅       | Owner's Firebase Auth UID                      |
+| `title`         | string          | ✅       | Project title (max 200 chars)                  |
+| `contentHash`   | string          | ✅       | SHA-256 hex of canvas PNG (64 chars)           |
+| `storageURL`    | string          |          | Firebase Storage download URL                  |
+| `thumbnailData` | string          |          | Base64 data:image/ URI (500 KB, 200px max)     |
+| `width`         | integer         |          | Canvas width in pixels                         |
+| `height`        | integer         |          | Canvas height in pixels                        |
+| `isPublic`      | boolean         |          | Public visibility flag (default `false`)       |
+| `tags`          | array\<string\> |          | Tags (max 20, each max 50 chars)               |
+| `createdAt`     | timestamp       | ✅       | Creation timestamp                             |
+| `updatedAt`     | timestamp       | ✅       | Last update timestamp                          |
 
 **Composite index**: `userId ASC, createdAt DESC` (for user's project listing)
 
@@ -123,18 +122,18 @@ Canvas projects. Auto-generated document IDs.
 
 Public gallery items. Sharing to gallery is an explicit user action that opts the item into public visibility.
 
-| Field           | Type            | Required | Description                  |
-| --------------- | --------------- | -------- | ---------------------------- |
-| `userId`        | string          | ✅       | Owner's Firebase Auth UID    |
-| `projectId`     | string          |          | Source project ID            |
-| `name`          | string          | ✅       | Item name (max 200 chars)    |
-| `description`   | string          |          | Description (max 2000 chars) |
-| `imageData`     | string          |          | Base64-encoded image         |
-| `thumbnailData` | string          |          | Base64-encoded thumbnail     |
-| `width`         | integer         |          | Image width                  |
-| `height`        | integer         |          | Image height                 |
-| `tags`          | array\<string\> |          | Tags                         |
-| `createdAt`     | timestamp       | ✅       | Creation timestamp           |
+| Field           | Type            | Required | Description                                   |
+| --------------- | --------------- | -------- | --------------------------------------------- |
+| `userId`        | string          | ✅       | Owner's Firebase Auth UID                     |
+| `projectId`     | string          |          | Source project ID                             |
+| `name`          | string          | ✅       | Item name (max 200 chars)                     |
+| `description`   | string          |          | Description (max 2000 chars)                  |
+| `imageData`     | string          |          | Base64-encoded image (max 500 KB)             |
+| `thumbnailData` | string          |          | Base64 data:image/ URI thumbnail (max 500 KB) |
+| `width`         | integer         |          | Image width                                   |
+| `height`        | integer         |          | Image height                                  |
+| `tags`          | array\<string\> |          | Tags                                          |
+| `createdAt`     | timestamp       | ✅       | Creation timestamp                            |
 
 **Composite index**: `userId ASC, createdAt DESC`
 
@@ -142,22 +141,22 @@ Public gallery items. Sharing to gallery is an explicit user action that opts th
 
 NFT records with Hiero (Hedera) network metadata.
 
-| Field           | Type      | Required | Description               |
-| --------------- | --------- | -------- | ------------------------- |
-| `userId`        | string    | ✅       | Owner's Firebase Auth UID |
-| `name`          | string    | ✅       | NFT name (max 200 chars)  |
-| `description`   | string    |          | Description               |
-| `imageData`     | string    |          | Base64-encoded image      |
-| `imageUrl`      | string    |          | External image URL        |
-| `thumbnailData` | string    |          | Base64-encoded thumbnail  |
-| `metadata`      | string    |          | NFT metadata JSON         |
-| `price`         | number    |          | Price in HBAR (≥ 0)       |
-| `isListed`      | boolean   |          | Whether listed for sale   |
-| `tokenId`       | string    |          | Hiero network token ID    |
-| `serialNumber`  | integer   |          | Hiero NFT serial number   |
-| `transactionId` | string    |          | Hiero transaction ID      |
-| `createdAt`     | timestamp | ✅       | Creation timestamp        |
-| `updatedAt`     | timestamp | ✅       | Last update timestamp     |
+| Field           | Type      | Required | Description                                   |
+| --------------- | --------- | -------- | --------------------------------------------- |
+| `userId`        | string    | ✅       | Owner's Firebase Auth UID                     |
+| `name`          | string    | ✅       | NFT name (max 200 chars)                      |
+| `description`   | string    |          | Description                                   |
+| `imageData`     | string    |          | Base64-encoded image (max 500 KB)             |
+| `imageUrl`      | string    |          | External image URL (http/https only)          |
+| `thumbnailData` | string    |          | Base64 data:image/ URI thumbnail (max 500 KB) |
+| `metadata`      | string    |          | NFT metadata JSON                             |
+| `price`         | number    |          | Price in HBAR (≥ 0)                           |
+| `isListed`      | boolean   |          | Whether listed for sale                       |
+| `tokenId`       | string    |          | Hiero network token ID                        |
+| `serialNumber`  | integer   |          | Hiero NFT serial number                       |
+| `transactionId` | string    |          | Hiero transaction ID                          |
+| `createdAt`     | timestamp | ✅       | Creation timestamp                            |
+| `updatedAt`     | timestamp | ✅       | Last update timestamp                         |
 
 **Composite index**: `userId ASC, createdAt DESC`
 
@@ -168,14 +167,17 @@ NFT records with Hiero (Hedera) network metadata.
 Rules are defined in [`firestore.rules`](../firestore.rules) and deployed via `firebase deploy --only firestore:rules`.
 
 ```text
-Collection     Read                                    Write                              Create
-─────────────  ──────────────────────────────────────  ─────────────────────────────────  ──────────────────────────
-usernames      Any authenticated user                  ✗ (updates forbidden)              Owner only (uid match)
-users          Owner only                              Owner only                         Owner only
-projects       Owner OR isPublic == true               Owner only                         Owner only (userId match)
-gallery        Any authenticated user (public by       Owner only                         Owner only (userId match)
+Collection     Read                                    Create                             Update                                Delete
+─────────────  ──────────────────────────────────────  ─────────────────────────────────  ────────────────────────────────────  ──────────────
+usernames      Any authenticated user                  Owner only (uid match)              ✗ (forbidden)                         Owner only
+users          Owner only                              Owner only                         Owner only                            Owner only
+projects       Owner OR isPublic == true               Owner only (userId match)           Owner only; userId & contentHash      Owner only
+                                                                                          immutable; only title, isPublic,
+                                                                                          tags, storageURL, updatedAt,
+                                                                                          thumbnailData may change
+gallery        Any authenticated user (public by       Owner only (userId match)           Owner only                            Owner only
                design — sharing = opting in)
-nfts           Owner OR isListed == true               Owner only                         Owner only (userId match)
+nfts           Owner OR isListed == true               Owner only (userId match)           Owner only                            Owner only
 ```
 
 > **Note**: The Go backend uses the Firebase Admin SDK, which **bypasses**

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -49,6 +49,7 @@ paintbar/
 │   │
 │   ├── repository/               # Data access layer
 │   │   ├── firestore.go          # Firebase client initialization + health check
+│   │   ├── storage.go            # StorageService — signed URLs + blob delete
 │   │   ├── user.go               # UserRepository interface + Firestore impl
 │   │   ├── project.go            # ProjectRepository interface + Firestore impl
 │   │   ├── gallery.go            # GalleryRepository interface + Firestore impl
@@ -88,6 +89,7 @@ paintbar/
 │   │   │   ├── actionTools.ts    # Selection tool (getImageData/putImageData)
 │   │   │   ├── genericTool.ts    # GenericTool base class
 │   │   │   ├── save.ts           # SaveManager — PNG, JPG, ICO export
+│   │   │   ├── project.ts        # ProjectManager — save project to server (hash, upload, confirm)
 │   │   │   └── iro.d.ts          # Type declarations for iro.js color picker
 │   │   ├── profile/
 │   │   │   └── profile.ts        # Profile page — fetch API, form handling
@@ -119,6 +121,7 @@ paintbar/
 ├── firebase.json                 # Firebase Hosting config + Firestore rules/indexes
 ├── firestore.rules               # Firestore security rules
 ├── firestore.indexes.json        # Firestore composite index definitions
+├── storage.rules                 # Firebase Storage security rules
 ├── .firebaserc                   # Firebase project alias (paintbar-7f887)
 ├── go.mod / go.sum               # Go module dependencies
 ├── package.json / package-lock.json # Node dependencies (esbuild, TypeScript)

--- a/firebase.json
+++ b/firebase.json
@@ -3,6 +3,9 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
+  "storage": {
+    "rules": "storage.rules"
+  },
   "hosting": {
     "public": "public",
     "ignore": [

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -9,6 +9,22 @@
       ]
     },
     {
+      "collectionGroup": "projects",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "title", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "projects",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "contentHash", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "gallery",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -28,8 +28,15 @@ service cloud.firestore {
     // Projects collection
     match /projects/{projectId} {
       allow read: if isAuthenticated() && (request.auth.uid == resource.data.userId || resource.data.isPublic == true);
-      allow write: if isAuthenticated() && request.auth.uid == resource.data.userId;
       allow create: if isAuthenticated() && request.resource.data.userId == request.auth.uid;
+      // Only allow updating safe fields — storageURL, contentHash, userId are immutable after creation
+      allow update: if isAuthenticated()
+                    && request.auth.uid == resource.data.userId
+                    && request.resource.data.userId == resource.data.userId
+                    && request.resource.data.contentHash == resource.data.contentHash
+                    && request.resource.data.diff(resource.data).affectedKeys()
+                       .hasOnly(['title', 'isPublic', 'tags', 'storageURL', 'updatedAt', 'thumbnailData']);
+      allow delete: if isAuthenticated() && request.auth.uid == resource.data.userId;
     }
 
     // Gallery collection — sharing to gallery is an explicit user action that

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25
 
 require (
 	cloud.google.com/go/firestore v1.21.0
+	cloud.google.com/go/storage v1.56.0
 	firebase.google.com/go/v4 v4.19.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/stretchr/testify v1.11.1
@@ -19,7 +20,6 @@ require (
 	cloud.google.com/go/iam v1.5.3 // indirect
 	cloud.google.com/go/longrunning v0.8.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
-	cloud.google.com/go/storage v1.56.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,12 @@ type Config struct {
 	// Firebase Auth emulator (local only, set automatically)
 	FirebaseAuthEmulatorHost string
 
+	// Firebase Storage bucket name
+	FirebaseStorageBucket string
+
+	// Firebase Storage emulator host (local only, set automatically)
+	FirebaseStorageEmulatorHost string
+
 	// Hiero network configuration
 	HieroNetwork     string // local, testnet, mainnet
 	HieroOperatorID  string
@@ -39,15 +45,17 @@ type Config struct {
 // Load reads configuration from environment variables and validates it.
 func Load() (*Config, error) {
 	cfg := &Config{
-		Env:                        getEnv("ENV", EnvLocal),
-		Port:                       getEnv("PORT", "8080"),
-		FirebaseProjectID:          getEnv("FIREBASE_PROJECT_ID", "paintbar-7f887"),
-		FirebaseServiceAccountPath: getEnv("FIREBASE_SERVICE_ACCOUNT_PATH", ""),
-		FirestoreEmulatorHost:      getEnv("FIRESTORE_EMULATOR_HOST", ""),
-		FirebaseAuthEmulatorHost:   getEnv("FIREBASE_AUTH_EMULATOR_HOST", ""),
-		HieroNetwork:               getEnv("HIERO_NETWORK", "local"),
-		HieroOperatorID:            getEnv("HIERO_OPERATOR_ID", ""),
-		HieroOperatorKey:           getEnv("HIERO_OPERATOR_KEY", ""),
+		Env:                         getEnv("ENV", EnvLocal),
+		Port:                        getEnv("PORT", "8080"),
+		FirebaseProjectID:           getEnv("FIREBASE_PROJECT_ID", "paintbar-7f887"),
+		FirebaseServiceAccountPath:  getEnv("FIREBASE_SERVICE_ACCOUNT_PATH", ""),
+		FirestoreEmulatorHost:       getEnv("FIRESTORE_EMULATOR_HOST", ""),
+		FirebaseAuthEmulatorHost:    getEnv("FIREBASE_AUTH_EMULATOR_HOST", ""),
+		FirebaseStorageBucket:       getEnv("FIREBASE_STORAGE_BUCKET", "paintbar-7f887.firebasestorage.app"),
+		FirebaseStorageEmulatorHost: getEnv("FIREBASE_STORAGE_EMULATOR_HOST", ""),
+		HieroNetwork:                getEnv("HIERO_NETWORK", "local"),
+		HieroOperatorID:             getEnv("HIERO_OPERATOR_ID", ""),
+		HieroOperatorKey:            getEnv("HIERO_OPERATOR_KEY", ""),
 	}
 
 	// Auto-configure emulator hosts for local environment
@@ -57,6 +65,9 @@ func Load() (*Config, error) {
 		}
 		if cfg.FirebaseAuthEmulatorHost == "" {
 			cfg.FirebaseAuthEmulatorHost = "localhost:9099"
+		}
+		if cfg.FirebaseStorageEmulatorHost == "" {
+			cfg.FirebaseStorageEmulatorHost = "localhost:9199"
 		}
 		if cfg.HieroNetwork == "" {
 			cfg.HieroNetwork = "local"

--- a/internal/model/gallery.go
+++ b/internal/model/gallery.go
@@ -35,6 +35,16 @@ func (g *GalleryItem) Validate() error {
 	if len(g.Description) > 2000 {
 		return fmt.Errorf("description must be 2000 characters or less")
 	}
+	if g.ThumbnailData != "" {
+		if err := ValidateThumbnailData(g.ThumbnailData); err != nil {
+			return err
+		}
+	}
+	if g.ImageData != "" {
+		if len(g.ImageData) > MaxThumbnailDataLen {
+			return fmt.Errorf("imageData must be %d bytes or less", MaxThumbnailDataLen)
+		}
+	}
 	return nil
 }
 

--- a/internal/model/nft.go
+++ b/internal/model/nft.go
@@ -41,6 +41,21 @@ func (n *NFT) Validate() error {
 	if n.Price < 0 {
 		return fmt.Errorf("price must be non-negative")
 	}
+	if n.ThumbnailData != "" {
+		if err := ValidateThumbnailData(n.ThumbnailData); err != nil {
+			return err
+		}
+	}
+	if n.ImageData != "" {
+		if len(n.ImageData) > MaxThumbnailDataLen {
+			return fmt.Errorf("imageData must be %d bytes or less", MaxThumbnailDataLen)
+		}
+	}
+	if n.ImageURL != "" {
+		if err := validateURL(n.ImageURL); err != nil {
+			return fmt.Errorf("invalid image URL: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/model/project.go
+++ b/internal/model/project.go
@@ -2,17 +2,27 @@ package model
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
+
+// contentHashRegex matches a 64-character lowercase hex string (SHA-256).
+var contentHashRegex = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// MaxThumbnailDataLen is the maximum allowed length of a base64 thumbnail data URL (500 KB).
+const MaxThumbnailDataLen = 500 * 1024
+
+// thumbnailDataPrefix is the required prefix for thumbnail data URLs.
+const thumbnailDataPrefix = "data:image/"
 
 // Project represents a canvas project stored in Firestore.
 type Project struct {
 	ID            string    `firestore:"-" json:"id"`
 	UserID        string    `firestore:"userId" json:"userId"`
-	Name          string    `firestore:"name" json:"name"`
-	Description   string    `firestore:"description,omitempty" json:"description,omitempty"`
-	ImageData     string    `firestore:"imageData,omitempty" json:"imageData,omitempty"`
+	Title         string    `firestore:"title" json:"title"`
+	ContentHash   string    `firestore:"contentHash" json:"contentHash"`
+	StorageURL    string    `firestore:"storageURL,omitempty" json:"storageURL,omitempty"`
 	ThumbnailData string    `firestore:"thumbnailData,omitempty" json:"thumbnailData,omitempty"`
 	Width         int       `firestore:"width,omitempty" json:"width,omitempty"`
 	Height        int       `firestore:"height,omitempty" json:"height,omitempty"`
@@ -24,14 +34,9 @@ type Project struct {
 
 // ProjectUpdate represents a partial update to a project.
 type ProjectUpdate struct {
-	Name          *string  `firestore:"name,omitempty" json:"name,omitempty"`
-	Description   *string  `firestore:"description,omitempty" json:"description,omitempty"`
-	ImageData     *string  `firestore:"imageData,omitempty" json:"imageData,omitempty"`
-	ThumbnailData *string  `firestore:"thumbnailData,omitempty" json:"thumbnailData,omitempty"`
-	Width         *int     `firestore:"width,omitempty" json:"width,omitempty"`
-	Height        *int     `firestore:"height,omitempty" json:"height,omitempty"`
-	IsPublic      *bool    `firestore:"isPublic,omitempty" json:"isPublic,omitempty"`
-	Tags          []string `firestore:"tags,omitempty" json:"tags,omitempty"`
+	Title    *string  `firestore:"title,omitempty" json:"title,omitempty"`
+	IsPublic *bool    `firestore:"isPublic,omitempty" json:"isPublic,omitempty"`
+	Tags     []string `firestore:"tags,omitempty" json:"tags,omitempty"`
 }
 
 // Validate checks that the Project has required fields and valid values.
@@ -39,14 +44,19 @@ func (p *Project) Validate() error {
 	if p.UserID == "" {
 		return fmt.Errorf("userId is required")
 	}
-	if strings.TrimSpace(p.Name) == "" {
-		return fmt.Errorf("name is required")
+	if strings.TrimSpace(p.Title) == "" {
+		return fmt.Errorf("title is required")
 	}
-	if len(p.Name) > 200 {
-		return fmt.Errorf("name must be 200 characters or less")
+	if len(p.Title) > 200 {
+		return fmt.Errorf("title must be 200 characters or less")
 	}
-	if len(p.Description) > 2000 {
-		return fmt.Errorf("description must be 2000 characters or less")
+	if p.ContentHash != "" && !contentHashRegex.MatchString(p.ContentHash) {
+		return fmt.Errorf("contentHash must be a 64-character lowercase hex string")
+	}
+	if p.ThumbnailData != "" {
+		if err := ValidateThumbnailData(p.ThumbnailData); err != nil {
+			return err
+		}
 	}
 	if len(p.Tags) > 20 {
 		return fmt.Errorf("maximum 20 tags allowed")
@@ -61,33 +71,53 @@ func (p *Project) Validate() error {
 
 // Sanitize cleans project input.
 func (p *Project) Sanitize() {
-	p.Name = strings.TrimSpace(p.Name)
-	p.Description = strings.TrimSpace(p.Description)
+	p.Title = strings.TrimSpace(p.Title)
 	for i, tag := range p.Tags {
 		p.Tags[i] = strings.TrimSpace(strings.ToLower(tag))
 	}
 }
 
+// Validate checks that the ProjectUpdate has valid values.
+func (p *ProjectUpdate) Validate() error {
+	if p.Title != nil {
+		title := strings.TrimSpace(*p.Title)
+		if title == "" {
+			return fmt.Errorf("title is required")
+		}
+		if len(title) > 200 {
+			return fmt.Errorf("title must be 200 characters or less")
+		}
+	}
+	if p.Tags != nil {
+		if len(p.Tags) > 20 {
+			return fmt.Errorf("maximum 20 tags allowed")
+		}
+		for _, tag := range p.Tags {
+			if len(tag) > 50 {
+				return fmt.Errorf("each tag must be 50 characters or less")
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateThumbnailData checks that a thumbnail data URL is a valid data:image/ URI
+// and does not exceed MaxThumbnailDataLen.
+func ValidateThumbnailData(data string) error {
+	if len(data) > MaxThumbnailDataLen {
+		return fmt.Errorf("thumbnailData must be %d bytes or less", MaxThumbnailDataLen)
+	}
+	if !strings.HasPrefix(data, thumbnailDataPrefix) {
+		return fmt.Errorf("thumbnailData must be a data:image/ URI")
+	}
+	return nil
+}
+
 // ToUpdateMap converts a ProjectUpdate to a map for Firestore partial updates.
 func (p *ProjectUpdate) ToUpdateMap() map[string]interface{} {
 	m := make(map[string]interface{})
-	if p.Name != nil {
-		m["name"] = *p.Name
-	}
-	if p.Description != nil {
-		m["description"] = *p.Description
-	}
-	if p.ImageData != nil {
-		m["imageData"] = *p.ImageData
-	}
-	if p.ThumbnailData != nil {
-		m["thumbnailData"] = *p.ThumbnailData
-	}
-	if p.Width != nil {
-		m["width"] = *p.Width
-	}
-	if p.Height != nil {
-		m["height"] = *p.Height
+	if p.Title != nil {
+		m["title"] = *p.Title
 	}
 	if p.IsPublic != nil {
 		m["isPublic"] = *p.IsPublic

--- a/internal/repository/gallery.go
+++ b/internal/repository/gallery.go
@@ -54,7 +54,7 @@ func (r *firestoreGalleryRepo) List(ctx context.Context, userID string, pageLimi
 	if startAfter != "" {
 		cursorDoc, err := r.client.Collection("gallery").Doc(startAfter).Get(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("get cursor doc %s: %w", startAfter, err)
+			return []*model.GalleryItem{}, nil
 		}
 		q = q.StartAfter(cursorDoc)
 	}

--- a/internal/repository/nft.go
+++ b/internal/repository/nft.go
@@ -55,7 +55,7 @@ func (r *firestoreNFTRepo) List(ctx context.Context, userID string, pageLimit in
 	if startAfter != "" {
 		cursorDoc, err := r.client.Collection("nfts").Doc(startAfter).Get(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("get cursor doc %s: %w", startAfter, err)
+			return []*model.NFT{}, nil
 		}
 		q = q.StartAfter(cursorDoc)
 	}

--- a/internal/repository/project.go
+++ b/internal/repository/project.go
@@ -13,10 +13,13 @@ import (
 // ProjectRepository defines the interface for project persistence operations.
 type ProjectRepository interface {
 	GetByID(ctx context.Context, projectID string) (*model.Project, error)
+	FindByContentHash(ctx context.Context, userID, contentHash string) (*model.Project, error)
+	FindByTitle(ctx context.Context, userID, title string) (*model.Project, error)
 	List(ctx context.Context, userID string, limit int, startAfter string) ([]*model.Project, error)
 	Count(ctx context.Context, userID string) (int64, error)
 	Create(ctx context.Context, project *model.Project) (string, error)
 	Update(ctx context.Context, projectID string, update *model.ProjectUpdate) error
+	UpdateRaw(ctx context.Context, projectID string, fields map[string]interface{}) error
 	Delete(ctx context.Context, projectID string) error
 }
 
@@ -45,6 +48,58 @@ func (r *firestoreProjectRepo) GetByID(ctx context.Context, projectID string) (*
 	return &project, nil
 }
 
+// FindByContentHash looks up a project by user ID and content hash for deduplication.
+// Returns nil, nil if no matching project is found.
+func (r *firestoreProjectRepo) FindByContentHash(ctx context.Context, userID, contentHash string) (*model.Project, error) {
+	iter := r.client.Collection("projects").
+		Where("userId", "==", userID).
+		Where("contentHash", "==", contentHash).
+		Limit(1).
+		Documents(ctx)
+	defer iter.Stop()
+
+	doc, err := iter.Next()
+	if err == iterator.Done {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find project by content hash: %w", err)
+	}
+
+	var project model.Project
+	if err := doc.DataTo(&project); err != nil {
+		return nil, fmt.Errorf("decode project: %w", err)
+	}
+	project.ID = doc.Ref.ID
+	return &project, nil
+}
+
+// FindByTitle looks up a project by user ID and title.
+// Returns nil, nil if no matching project is found.
+func (r *firestoreProjectRepo) FindByTitle(ctx context.Context, userID, title string) (*model.Project, error) {
+	iter := r.client.Collection("projects").
+		Where("userId", "==", userID).
+		Where("title", "==", title).
+		Limit(1).
+		Documents(ctx)
+	defer iter.Stop()
+
+	doc, err := iter.Next()
+	if err == iterator.Done {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find project by title: %w", err)
+	}
+
+	var project model.Project
+	if err := doc.DataTo(&project); err != nil {
+		return nil, fmt.Errorf("decode project: %w", err)
+	}
+	project.ID = doc.Ref.ID
+	return &project, nil
+}
+
 // List retrieves projects for a user, ordered by createdAt descending, with cursor pagination.
 func (r *firestoreProjectRepo) List(ctx context.Context, userID string, pageLimit int, startAfter string) ([]*model.Project, error) {
 	q := r.client.Collection("projects").
@@ -56,7 +111,9 @@ func (r *firestoreProjectRepo) List(ctx context.Context, userID string, pageLimi
 	if startAfter != "" {
 		cursorDoc, err := r.client.Collection("projects").Doc(startAfter).Get(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("get cursor doc %s: %w", startAfter, err)
+			// If cursor doc doesn't exist, return empty results rather than
+			// exposing whether a document ID exists (information disclosure).
+			return []*model.Project{}, nil
 		}
 		q = q.StartAfter(cursorDoc)
 	}
@@ -131,6 +188,16 @@ func (r *firestoreProjectRepo) Update(ctx context.Context, projectID string, upd
 	_, err := r.client.Collection("projects").Doc(projectID).Set(ctx, updates, firestore.MergeAll)
 	if err != nil {
 		return fmt.Errorf("update project %s: %w", projectID, err)
+	}
+	return nil
+}
+
+// UpdateRaw applies a raw map of field updates to a project document.
+// Used for internal updates (e.g. setting storageURL) that aren't part of ProjectUpdate.
+func (r *firestoreProjectRepo) UpdateRaw(ctx context.Context, projectID string, fields map[string]interface{}) error {
+	_, err := r.client.Collection("projects").Doc(projectID).Set(ctx, fields, firestore.MergeAll)
+	if err != nil {
+		return fmt.Errorf("update raw project %s: %w", projectID, err)
 	}
 	return nil
 }

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -44,4 +45,77 @@ func TestFirebaseClients_Close_Nil(t *testing.T) {
 	fc := &FirebaseClients{}
 	err := fc.Close()
 	assert.NoError(t, err)
+}
+
+// --- Storage helper tests ---
+
+func TestProjectObjectPath(t *testing.T) {
+	path, err := ProjectObjectPath("user123", "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+	assert.NoError(t, err)
+	assert.Equal(t, "projects/user123/abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890.png", path)
+}
+
+func TestProjectObjectPath_Format(t *testing.T) {
+	path, err := ProjectObjectPath("uid1", "hash1")
+	assert.NoError(t, err)
+	assert.Equal(t, "projects/uid1/hash1.png", path)
+}
+
+func TestProjectObjectPath_EmptyUserID(t *testing.T) {
+	_, err := ProjectObjectPath("", "hash1")
+	assert.ErrorContains(t, err, "invalid userID")
+}
+
+func TestProjectObjectPath_EmptyContentHash(t *testing.T) {
+	_, err := ProjectObjectPath("uid1", "")
+	assert.ErrorContains(t, err, "invalid contentHash")
+}
+
+func TestProjectObjectPath_TraversalInUserID(t *testing.T) {
+	_, err := ProjectObjectPath("../etc", "hash1")
+	assert.ErrorContains(t, err, "path separators or traversal")
+}
+
+func TestProjectObjectPath_SlashInUserID(t *testing.T) {
+	_, err := ProjectObjectPath("user/evil", "hash1")
+	assert.ErrorContains(t, err, "path separators or traversal")
+}
+
+func TestProjectObjectPath_BackslashInContentHash(t *testing.T) {
+	_, err := ProjectObjectPath("uid1", "hash\\evil")
+	assert.ErrorContains(t, err, "path separators or traversal")
+}
+
+func TestProjectObjectPath_TraversalInContentHash(t *testing.T) {
+	_, err := ProjectObjectPath("uid1", "..somehash")
+	assert.ErrorContains(t, err, "path separators or traversal")
+}
+
+func TestNewStorageService(t *testing.T) {
+	svc := NewStorageService(nil, "test-bucket", "")
+	assert.NotNil(t, svc)
+}
+
+func TestStorageService_EmulatorUploadURL(t *testing.T) {
+	svc := NewStorageService(nil, "my-bucket.appspot.com", "localhost:9199")
+	url, err := svc.GenerateUploadURL("projects/uid1/abc123.png", 15*time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, "http://localhost:9199/upload/storage/v1/b/my-bucket.appspot.com/o?uploadType=media&name=projects%2Fuid1%2Fabc123.png", url)
+}
+
+func TestStorageService_EmulatorDownloadURL(t *testing.T) {
+	svc := NewStorageService(nil, "my-bucket.appspot.com", "localhost:9199")
+	url, err := svc.GenerateDownloadURL("projects/uid1/abc123.png", 15*time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, "http://localhost:9199/v0/b/my-bucket.appspot.com/o/projects%2Fuid1%2Fabc123.png?alt=media", url)
+}
+
+func TestValidatePathSegment(t *testing.T) {
+	assert.NoError(t, validatePathSegment("valid-segment"))
+	assert.NoError(t, validatePathSegment("abc123"))
+	assert.Error(t, validatePathSegment(""))
+	assert.Error(t, validatePathSegment("a/b"))
+	assert.Error(t, validatePathSegment("a\\b"))
+	assert.Error(t, validatePathSegment(".."))
+	assert.Error(t, validatePathSegment("a..b"))
 }

--- a/internal/repository/storage.go
+++ b/internal/repository/storage.go
@@ -1,0 +1,141 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	gcs "cloud.google.com/go/storage"
+)
+
+// StorageService provides operations on Firebase/Cloud Storage for project blobs.
+type StorageService struct {
+	bucket       *gcs.BucketHandle
+	bucketName   string
+	emulatorHost string
+}
+
+// NewStorageService creates a StorageService backed by the given bucket.
+// If emulatorHost is non-empty (e.g. "localhost:9199"), the service generates
+// direct emulator URLs instead of V4 signed URLs.
+func NewStorageService(bucket *gcs.BucketHandle, bucketName, emulatorHost string) *StorageService {
+	return &StorageService{bucket: bucket, bucketName: bucketName, emulatorHost: emulatorHost}
+}
+
+// GenerateUploadURL creates a V4-signed URL that allows a client to PUT a PNG
+// blob directly to Cloud Storage. The URL is scoped to the given object path
+// and expires after the specified duration.
+//
+// When running against the Firebase Storage emulator, signed URLs are not
+// supported, so a direct emulator upload URL is returned instead.
+func (s *StorageService) GenerateUploadURL(objectPath string, expiry time.Duration) (string, error) {
+	if s.emulatorHost != "" {
+		return s.emulatorUploadURL(objectPath), nil
+	}
+	url, err := s.bucket.SignedURL(objectPath, &gcs.SignedURLOptions{
+		Method:      "PUT",
+		Expires:     time.Now().Add(expiry),
+		ContentType: "image/png",
+		Scheme:      gcs.SigningSchemeV4,
+	})
+	if err != nil {
+		return "", fmt.Errorf("generate upload signed url: %w", err)
+	}
+	return url, nil
+}
+
+// GenerateDownloadURL creates a V4-signed URL that allows anyone to GET the
+// object for the specified duration.
+//
+// When running against the Firebase Storage emulator, a direct emulator URL
+// is returned instead of a signed URL.
+func (s *StorageService) GenerateDownloadURL(objectPath string, expiry time.Duration) (string, error) {
+	if s.emulatorHost != "" {
+		return s.emulatorObjectURL(objectPath), nil
+	}
+	url, err := s.bucket.SignedURL(objectPath, &gcs.SignedURLOptions{
+		Method:  "GET",
+		Expires: time.Now().Add(expiry),
+		Scheme:  gcs.SigningSchemeV4,
+	})
+	if err != nil {
+		return "", fmt.Errorf("generate download signed url: %w", err)
+	}
+	return url, nil
+}
+
+// emulatorUploadURL returns the Firebase Storage emulator upload endpoint.
+// Format: http://{emulatorHost}/upload/storage/v1/b/{bucket}/o?uploadType=media&name={path}
+// The client must POST (not PUT) to this URL with the file body.
+func (s *StorageService) emulatorUploadURL(objectPath string) string {
+	encoded := strings.ReplaceAll(objectPath, "/", "%2F")
+	return fmt.Sprintf("http://%s/upload/storage/v1/b/%s/o?uploadType=media&name=%s", s.emulatorHost, s.bucketName, encoded)
+}
+
+// emulatorObjectURL returns a direct URL to an object in the Firebase Storage emulator.
+// Format: http://{emulatorHost}/v0/b/{bucket}/o/{urlEncodedPath}?alt=media
+func (s *StorageService) emulatorObjectURL(objectPath string) string {
+	encoded := strings.ReplaceAll(objectPath, "/", "%2F")
+	return fmt.Sprintf("http://%s/v0/b/%s/o/%s?alt=media", s.emulatorHost, s.bucketName, encoded)
+}
+
+// ReadObject opens a streaming reader for an object in Storage.
+// The caller must close the returned ReadCloser when done.
+func (s *StorageService) ReadObject(ctx context.Context, objectPath string) (io.ReadCloser, error) {
+	reader, err := s.bucket.Object(objectPath).NewReader(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("open object for read: %w", err)
+	}
+	return reader, nil
+}
+
+// ObjectExists checks whether an object exists at the given path.
+func (s *StorageService) ObjectExists(ctx context.Context, objectPath string) (bool, error) {
+	_, err := s.bucket.Object(objectPath).Attrs(ctx)
+	if err == gcs.ErrObjectNotExist {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check object exists: %w", err)
+	}
+	return true, nil
+}
+
+// DeleteObject removes the object at the given path. Returns nil if the object
+// does not exist (idempotent).
+func (s *StorageService) DeleteObject(ctx context.Context, objectPath string) error {
+	err := s.bucket.Object(objectPath).Delete(ctx)
+	if err == gcs.ErrObjectNotExist {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("delete object: %w", err)
+	}
+	return nil
+}
+
+// ProjectObjectPath returns the canonical storage path for a project's PNG blob.
+// Format: projects/{userID}/{contentHash}.png
+// Returns an error if either segment contains path traversal characters.
+func ProjectObjectPath(userID, contentHash string) (string, error) {
+	if err := validatePathSegment(userID); err != nil {
+		return "", fmt.Errorf("invalid userID: %w", err)
+	}
+	if err := validatePathSegment(contentHash); err != nil {
+		return "", fmt.Errorf("invalid contentHash: %w", err)
+	}
+	return fmt.Sprintf("projects/%s/%s.png", userID, contentHash), nil
+}
+
+// validatePathSegment rejects values that could escape the intended storage prefix.
+func validatePathSegment(s string) error {
+	if s == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	if strings.Contains(s, "/") || strings.Contains(s, "\\") || strings.Contains(s, "..") {
+		return fmt.Errorf("must not contain path separators or traversal sequences")
+	}
+	return nil
+}

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,25 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    // Project canvas PNG blobs: projects/{userId}/{contentHash}.png
+    match /projects/{userId}/{fileName} {
+      // Anyone authenticated can read (for public projects, download URL is shared)
+      allow read: if request.auth != null;
+
+      // Only the owner can create or overwrite, PNG only, max 10 MB
+      allow create, update: if request.auth != null
+                            && request.auth.uid == userId
+                            && request.resource.contentType == 'image/png'
+                            && request.resource.size < 10 * 1024 * 1024;
+
+      // Only the owner can delete
+      allow delete: if request.auth != null
+                    && request.auth.uid == userId;
+    }
+
+    // Deny all other paths by default
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/web/static/styles/profile.css
+++ b/web/static/styles/profile.css
@@ -374,13 +374,14 @@ body {
 }
 
 .project-card {
-    aspect-ratio: 1;
     border-radius: 8px;
     overflow: hidden;
     border: 1px solid var(--border-color);
     background: var(--card-background);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     transition: all 0.3s ease;
+    display: flex;
+    flex-direction: column;
 }
 
 .project-card:hover {
@@ -391,8 +392,62 @@ body {
 
 .project-card img {
     width: 100%;
-    height: 100%;
+    aspect-ratio: 1;
     object-fit: cover;
+}
+
+.project-info {
+    padding: 0.5rem 0.6rem 0.25rem;
+}
+
+.project-info h3 {
+    font-size: 0.85rem;
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--text-color);
+}
+
+.project-date {
+    font-size: 0.7rem;
+    color: var(--text-color);
+    opacity: 0.6;
+}
+
+.project-actions {
+    display: flex;
+    gap: 0.4rem;
+    padding: 0.25rem 0.6rem 0.5rem;
+}
+
+.project-action-btn {
+    flex: 1;
+    padding: 0.3rem 0;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.project-action-btn.open-btn {
+    background: var(--primary-color);
+    color: #000;
+}
+
+.project-action-btn.open-btn:hover {
+    background: #00e5e5;
+}
+
+.project-action-btn.delete-btn {
+    background: transparent;
+    color: #ff6b6b;
+    border: 1px solid #ff6b6b;
+}
+
+.project-action-btn.delete-btn:hover {
+    background: rgba(255, 107, 107, 0.15);
 }
 
 .copyright {

--- a/web/static/styles/styles.css
+++ b/web/static/styles/styles.css
@@ -1485,6 +1485,142 @@ body {
     color: white;
 }
 
+/* Save Project Modal */
+#saveProjectModal .modal-content {
+    min-width: 400px;
+    max-width: 500px;
+    background: rgba(49, 35, 58, 0.95);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: white;
+}
+
+#saveProjectModal .modal-header {
+    padding: 16px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+#saveProjectModal .modal-header h3 {
+    margin: 0;
+    color: white;
+}
+
+#saveProjectModal .modal-body {
+    padding: 16px;
+}
+
+#saveProjectModal .close-btn {
+    color: white;
+    opacity: 0.8;
+}
+
+#saveProjectModal .close-btn:hover {
+    opacity: 1;
+}
+
+.save-project-form .form-group {
+    margin-bottom: 16px;
+}
+
+.save-project-form .form-group label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.save-project-form .form-group .hint {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.save-project-form .form-group input[type="text"] {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.3);
+    color: white;
+    font-size: 14px;
+    box-sizing: border-box;
+}
+
+.save-project-form .form-group input[type="text"]:focus {
+    outline: none;
+    border-color: rgba(255, 255, 255, 0.5);
+}
+
+.save-project-form .form-group input[type="checkbox"] {
+    margin-right: 8px;
+    accent-color: #7c3aed;
+}
+
+.save-project-status {
+    padding: 10px 12px;
+    border-radius: 4px;
+    font-size: 13px;
+    margin-top: 8px;
+}
+
+.save-project-status.info {
+    background: rgba(59, 130, 246, 0.2);
+    border: 1px solid rgba(59, 130, 246, 0.4);
+    color: #93c5fd;
+}
+
+.save-project-status.success {
+    background: rgba(34, 197, 94, 0.2);
+    border: 1px solid rgba(34, 197, 94, 0.4);
+    color: #86efac;
+}
+
+.save-project-status.error {
+    background: rgba(239, 68, 68, 0.2);
+    border: 1px solid rgba(239, 68, 68, 0.4);
+    color: #fca5a5;
+}
+
+#saveProjectModal .modal-footer {
+    padding: 12px 16px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+#saveProjectModal .modal-footer button {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+#saveProjectModal .modal-footer .btn {
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+}
+
+#saveProjectModal .modal-footer .btn:hover {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+#saveProjectModal .modal-footer .primary-btn {
+    background: #7c3aed;
+    color: white;
+}
+
+#saveProjectModal .modal-footer .primary-btn:hover {
+    background: #6d28d9;
+}
+
+#saveProjectModal .modal-footer .primary-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .menu-icon {
     width: 24px;
     height: 24px;

--- a/web/templates/pages/canvas.html
+++ b/web/templates/pages/canvas.html
@@ -192,7 +192,8 @@
                     <span class="submenu-toggle">&#x25BC;</span>
                 </div>
                 <div class="submenu-content">
-                    <button id="saveBtn" title="Save">&#x1F4BE; Save</button>
+                    <button id="saveBtn" title="Save to Device">&#x1F4BE; Save</button>
+                    <button id="saveProjectBtn" title="Save Project">&#x2601; Save Project</button>
                 </div>
             </div>
 
@@ -333,6 +334,38 @@
                 </div>
                 <div class="modal-footer">
                     <button id="cancelSave" class="btn">Cancel</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="saveProjectModal" class="modal hidden">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3>Save Project</h3>
+                    <button id="closeSaveProjectBtn" class="close-btn">&times;</button>
+                </div>
+                <div class="modal-body">
+                    <div class="save-project-form">
+                        <div class="form-group">
+                            <label for="projectTitle">Title</label>
+                            <input type="text" id="projectTitle" maxlength="200" placeholder="My Artwork" autocomplete="off">
+                        </div>
+                        <div class="form-group">
+                            <label for="projectTags">Tags <span class="hint">(comma-separated, max 20)</span></label>
+                            <input type="text" id="projectTags" placeholder="landscape, pixel-art" autocomplete="off">
+                        </div>
+                        <div class="form-group">
+                            <label>
+                                <input type="checkbox" id="projectPublic">
+                                Make project public
+                            </label>
+                        </div>
+                        <div id="saveProjectStatus" class="save-project-status hidden"></div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button id="cancelSaveProject" class="btn">Cancel</button>
+                    <button id="confirmSaveProject" class="primary-btn">Save</button>
                 </div>
             </div>
         </div>

--- a/web/ts/canvas/project.ts
+++ b/web/ts/canvas/project.ts
@@ -1,0 +1,316 @@
+// ============================================================
+// ProjectManager — handles saving canvas projects to the server
+// ============================================================
+
+import { auth } from "../shared/firebase-init";
+import type { PaintBar } from "./app";
+
+/** Response from POST /api/projects */
+interface CreateProjectResult {
+  projectId: string;
+  uploadURL?: string;
+  duplicate: boolean;
+}
+
+/** Thumbnail max dimension in pixels */
+const THUMBNAIL_MAX_SIZE = 256;
+
+/**
+ * ProjectManager handles the full save-project flow:
+ * 1. Hash the canvas PNG blob (SHA-256)
+ * 2. Generate a thumbnail
+ * 3. POST /api/projects (dedup check + get signed upload URL)
+ * 4. PUT the PNG blob to the signed URL
+ * 5. POST /api/projects/{id}/confirm-upload
+ */
+export class ProjectManager {
+  private paintBar: PaintBar;
+
+  // Modal elements
+  private modal: HTMLElement | null;
+  private closeBtn: HTMLElement | null;
+  private cancelBtn: HTMLElement | null;
+  private confirmBtn: HTMLButtonElement | null;
+  private openBtn: HTMLElement | null;
+  private titleInput: HTMLInputElement | null;
+  private tagsInput: HTMLInputElement | null;
+  private publicCheckbox: HTMLInputElement | null;
+  private statusEl: HTMLElement | null;
+
+  private saving = false;
+  private loadedProjectId: string | null = null;
+
+  constructor(paintBar: PaintBar) {
+    this.paintBar = paintBar;
+
+    this.modal = document.getElementById("saveProjectModal");
+    this.closeBtn = document.getElementById("closeSaveProjectBtn");
+    this.cancelBtn = document.getElementById("cancelSaveProject");
+    this.confirmBtn = document.getElementById(
+      "confirmSaveProject",
+    ) as HTMLButtonElement | null;
+    this.openBtn = document.getElementById("saveProjectBtn");
+    this.titleInput = document.getElementById(
+      "projectTitle",
+    ) as HTMLInputElement | null;
+    this.tagsInput = document.getElementById(
+      "projectTags",
+    ) as HTMLInputElement | null;
+    this.publicCheckbox = document.getElementById(
+      "projectPublic",
+    ) as HTMLInputElement | null;
+    this.statusEl = document.getElementById("saveProjectStatus");
+
+    this.setupEventListeners();
+  }
+
+  /**
+   * Set the loaded project context so re-saves update the existing project
+   * instead of creating a new one. Pre-fills the title input.
+   */
+  setLoadedProject(projectId: string, title: string): void {
+    this.loadedProjectId = projectId;
+    if (this.titleInput) this.titleInput.value = title;
+  }
+
+  private setupEventListeners(): void {
+    this.openBtn?.addEventListener("click", () => this.showModal());
+    this.closeBtn?.addEventListener("click", () => this.hideModal());
+    this.cancelBtn?.addEventListener("click", () => this.hideModal());
+    this.confirmBtn?.addEventListener("click", () => this.saveProject());
+  }
+
+  private showModal(): void {
+    this.modal?.classList.remove("hidden");
+    this.clearStatus();
+    this.titleInput?.focus();
+  }
+
+  private hideModal(): void {
+    if (this.saving) return;
+    this.modal?.classList.add("hidden");
+    this.clearStatus();
+  }
+
+  private setStatus(message: string, type: "info" | "success" | "error"): void {
+    if (!this.statusEl) return;
+    this.statusEl.textContent = message;
+    this.statusEl.className = `save-project-status ${type}`;
+    this.statusEl.classList.remove("hidden");
+  }
+
+  private clearStatus(): void {
+    if (!this.statusEl) return;
+    this.statusEl.className = "save-project-status hidden";
+    this.statusEl.textContent = "";
+  }
+
+  private setButtonsDisabled(disabled: boolean): void {
+    if (this.confirmBtn) this.confirmBtn.disabled = disabled;
+    if (this.cancelBtn)
+      (this.cancelBtn as HTMLButtonElement).disabled = disabled;
+    if (this.closeBtn) (this.closeBtn as HTMLButtonElement).disabled = disabled;
+  }
+
+  /**
+   * Get the current user's Firebase ID token for API authentication.
+   */
+  private async getIdToken(): Promise<string> {
+    const user = auth.currentUser;
+    if (!user) {
+      throw new Error("Not authenticated");
+    }
+    return user.getIdToken();
+  }
+
+  /**
+   * Export the canvas (drawing + opaque background) as a PNG Blob.
+   */
+  private getCanvasBlob(): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+      const tempCanvas = document.createElement("canvas");
+      tempCanvas.width = this.paintBar.canvas.width;
+      tempCanvas.height = this.paintBar.canvas.height;
+      const ctx = tempCanvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("Could not create temp canvas context"));
+        return;
+      }
+
+      // Composite: opaque background + drawing layer
+      ctx.drawImage(this.paintBar.opaqueBgCanvas, 0, 0);
+      ctx.drawImage(this.paintBar.canvas, 0, 0);
+
+      tempCanvas.toBlob((blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Failed to export canvas as PNG"));
+        }
+      }, "image/png");
+    });
+  }
+
+  /**
+   * Compute SHA-256 hex digest of a Blob.
+   */
+  private async hashBlob(blob: Blob): Promise<string> {
+    const buffer = await blob.arrayBuffer();
+    const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+  }
+
+  /**
+   * Generate a base64-encoded thumbnail from the canvas.
+   */
+  private generateThumbnail(): string {
+    const srcCanvas = this.paintBar.canvas;
+    const srcBg = this.paintBar.opaqueBgCanvas;
+
+    const scale = Math.min(
+      THUMBNAIL_MAX_SIZE / srcCanvas.width,
+      THUMBNAIL_MAX_SIZE / srcCanvas.height,
+      1,
+    );
+    const w = Math.round(srcCanvas.width * scale);
+    const h = Math.round(srcCanvas.height * scale);
+
+    const thumbCanvas = document.createElement("canvas");
+    thumbCanvas.width = w;
+    thumbCanvas.height = h;
+    const ctx = thumbCanvas.getContext("2d")!;
+
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = "high";
+    ctx.drawImage(srcBg, 0, 0, w, h);
+    ctx.drawImage(srcCanvas, 0, 0, w, h);
+
+    return thumbCanvas.toDataURL("image/png");
+  }
+
+  /**
+   * Parse comma-separated tags from the input.
+   */
+  private parseTags(): string[] {
+    const raw = this.tagsInput?.value ?? "";
+    return raw
+      .split(",")
+      .map((t) => t.trim().toLowerCase())
+      .filter((t) => t.length > 0)
+      .slice(0, 20);
+  }
+
+  /**
+   * Main save flow.
+   */
+  private async saveProject(): Promise<void> {
+    if (this.saving) return;
+
+    const title = this.titleInput?.value.trim() ?? "";
+    if (!title) {
+      this.setStatus("Title is required.", "error");
+      this.titleInput?.focus();
+      return;
+    }
+
+    this.saving = true;
+    this.setButtonsDisabled(true);
+
+    try {
+      // Step 1: Export canvas + hash
+      this.setStatus("Preparing canvas...", "info");
+      const blob = await this.getCanvasBlob();
+      const contentHash = await this.hashBlob(blob);
+      const thumbnailData = this.generateThumbnail();
+      const tags = this.parseTags();
+      const isPublic = this.publicCheckbox?.checked ?? false;
+
+      // Step 2: Create project via API
+      this.setStatus("Creating project...", "info");
+      const token = await this.getIdToken();
+      const createRes = await fetch("/api/projects", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          title,
+          contentHash,
+          thumbnailData,
+          width: this.paintBar.canvas.width,
+          height: this.paintBar.canvas.height,
+          isPublic,
+          tags,
+        }),
+      });
+
+      if (!createRes.ok) {
+        const err = await createRes.json().catch(() => ({}));
+        throw new Error(
+          (err as { error?: string }).error ||
+            `Server error (${createRes.status})`,
+        );
+      }
+
+      const result: CreateProjectResult = await createRes.json();
+
+      if (result.duplicate) {
+        this.setStatus(
+          "Project already saved (duplicate detected).",
+          "success",
+        );
+        this.saving = false;
+        this.setButtonsDisabled(false);
+        setTimeout(() => this.hideModal(), 1500);
+        return;
+      }
+
+      // Step 3: Upload blob to signed URL (POST for emulator, PUT for production)
+      if (result.uploadURL) {
+        this.setStatus("Uploading canvas...", "info");
+        const isEmulator = result.uploadURL.includes("uploadType=media");
+        const uploadRes = await fetch(result.uploadURL, {
+          method: isEmulator ? "POST" : "PUT",
+          headers: { "Content-Type": "image/png" },
+          body: blob,
+        });
+
+        if (!uploadRes.ok) {
+          throw new Error(`Upload failed (${uploadRes.status})`);
+        }
+
+        // Step 4: Confirm upload
+        this.setStatus("Confirming upload...", "info");
+        const confirmRes = await fetch(
+          `/api/projects/${result.projectId}/confirm-upload`,
+          {
+            method: "POST",
+            headers: { Authorization: `Bearer ${token}` },
+          },
+        );
+
+        if (!confirmRes.ok) {
+          const err = await confirmRes.json().catch(() => ({}));
+          throw new Error(
+            (err as { error?: string }).error ||
+              `Confirm failed (${confirmRes.status})`,
+          );
+        }
+      }
+
+      this.setStatus("Project saved!", "success");
+      setTimeout(() => this.hideModal(), 1500);
+    } catch (err) {
+      console.error("Save project error:", err);
+      this.setStatus(
+        err instanceof Error ? err.message : "Failed to save project.",
+        "error",
+      );
+    } finally {
+      this.saving = false;
+      this.setButtonsDisabled(false);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces Firebase Storage integration for project PNG blobs, updates the project API to support upsert and blob upload/streaming, and refactors the project schema and documentation for clarity and consistency. Sensitive endpoints are now rate-limited, and emulator configuration is expanded to support Storage. The most important changes are grouped below:

**Firebase Storage Integration & Emulator Configuration**

* Added Firebase Storage bucket and emulator host configuration to `.env.example`, `docker-compose.yml`, and `Dockerfile.firebase`. The Storage emulator is now included in local development and exposed via Docker. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR16-R22) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R14-R15) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R31-R36) [[4]](diffhunk://#diff-cac7388abd187c82d033169ec77c2765b8e8841604897898e9f68fe85e869f75L9-R21)
* Initialized Storage client and service in `cmd/server/main.go`, passing bucket and emulator host to repository/service layers. [[1]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR54-R57) [[2]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR71-R77)

**Project API Enhancements**

* Updated `/api/projects` endpoint to support create/upsert logic: returns duplicate status if content hash matches, upserts if title matches, and provides upload URL for PNG blob. Added endpoints for project lookup by title, confirming blob upload, and streaming blobs. [[1]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3L158-R164) [[2]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3L168-R216) [[3]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R288-R338) [[4]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eL162-R178)
* Expanded OpenAPI schema: new `CreateProjectResult` response, updated request/response fields, and stricter validation for content hash and thumbnail data. [[1]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3L524-R634) [[2]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3L557-R668) [[3]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3L581-R709) [[4]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R728-R733) [[5]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R785-R794)

**Documentation Updates**

* Revised API documentation to match new project upsert logic, required fields, response structure, and blob upload/stream endpoints. [[1]](diffhunk://#diff-9eddf4dc51bf6a0125ca7fb094468ad284112270385c41cebce4f8f0a29620abR184-R195) [[2]](diffhunk://#diff-9eddf4dc51bf6a0125ca7fb094468ad284112270385c41cebce4f8f0a29620abL199-R246)
* Updated database schema docs to reflect new project fields (`title`, `contentHash`, `storageURL`, improved thumbnail).

**Rate Limiting Improvements**

* Sensitive endpoints (`POST /api/projects`, `POST /api/projects/{id}/confirm-upload`) are now rate-limited, with relaxed limits in local development and updated documentation. [[1]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eL91-R102) [[2]](diffhunk://#diff-9eddf4dc51bf6a0125ca7fb094468ad284112270385c41cebce4f8f0a29620abL312-R356)

**Backward-Incompatible Changes**

* Renamed project fields (`name` → `title`, removed `description` and `imageData`, added `contentHash`, `storageURL`, stricter thumbnail requirements), impacting API clients and database schema. [[1]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3L524-R634) [[2]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3L557-R668) [[3]](diffhunk://#diff-2cb2c2e30373bd9a6fd3890e6115c05e995e5bf146363e70be312819e7f22b63L83-R86)

## Related Issue(s)

Closes #90