### PR TITLE
feat: Use Gravatar (opt-in)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -614,6 +614,9 @@ components:
           type: string
         hbarAddress:
           type: string
+        useGravatar:
+          type: boolean
+          description: Whether to use Gravatar for the profile picture
         createdAt:
           type: string
           format: date-time
@@ -648,6 +651,9 @@ components:
           type: string
         hbarAddress:
           type: string
+        useGravatar:
+          type: boolean
+          description: Whether to use Gravatar for the profile picture
 
     Project:
       type: object

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -38,6 +38,7 @@ User profile documents. The `userId` is the Firebase Auth UID.
 | `blueskyHandle`   | string    | No       | Bluesky handle                              |
 | `instagramHandle` | string    | No       | Instagram handle                            |
 | `hbarAddress`     | string    | No       | Hedera HBAR wallet address                  |
+| `useGravatar`     | boolean   | No       | Whether to use Gravatar for profile picture |
 | `createdAt`       | timestamp | Yes      | Account creation timestamp                  |
 | `updatedAt`       | timestamp | Yes      | Last profile update timestamp               |
 
@@ -62,6 +63,7 @@ User profile documents. The `userId` is the Firebase Auth UID.
   "blueskyHandle": "@artist.bsky.social",
   "instagramHandle": "@artist",
   "hbarAddress": "0.0.123456",
+  "useGravatar": true,
   "createdAt": "2025-01-15T10:30:00Z",
   "updatedAt": "2025-01-20T14:45:00Z"
 }

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -40,6 +40,10 @@ paintbar/
 │   │   ├── recovery.go           # Panic recovery middleware
 │   │   └── security.go           # Security headers (CSP, HSTS, X-Frame-Options)
 │   │
+│   ├── gravatar/                 # Gravatar URL helper (MD5 hash, d=404)
+│   │   ├── gravatar.go           # URL(email, size) → Gravatar URL
+│   │   └── gravatar_test.go      # Gravatar helper unit tests
+│   │
 │   ├── model/                    # Domain models
 │   │   ├── user.go               # User, UserUpdate structs + validation
 │   │   ├── project.go            # Project, ProjectUpdate structs + validation
@@ -102,7 +106,8 @@ paintbar/
 │   │       ├── firebase-config.ts          # Firebase config (gitignored, generated)
 │   │       ├── firebase-config.template.ts # Template for firebase-config.ts
 │   │       ├── errors.ts         # Global error handler
-│   │       └── toast.ts          # Shared toast notification utility
+│   │       ├── toast.ts          # Shared toast notification utility
+│   │       └── gravatar.ts       # Gravatar URL helper (MD5 hash, onerror fallback)
 │   │
 │   └── static/                   # Served at /static/* by Go file server
 │       ├── dist/                 # esbuild output (gitignored)

--- a/internal/gravatar/gravatar.go
+++ b/internal/gravatar/gravatar.go
@@ -1,0 +1,16 @@
+package gravatar
+
+import (
+	"crypto/md5"
+	"fmt"
+	"strings"
+)
+
+// URL returns the Gravatar URL for the given email address at the specified
+// pixel size. The d=404 parameter causes Gravatar to return a 404 if no
+// avatar is registered, allowing the caller to fall back to a default image.
+func URL(email string, size int) string {
+	email = strings.TrimSpace(strings.ToLower(email))
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(email)))
+	return fmt.Sprintf("https://gravatar.com/avatar/%s?s=%d&d=404", hash, size)
+}

--- a/internal/gravatar/gravatar_test.go
+++ b/internal/gravatar/gravatar_test.go
@@ -1,0 +1,26 @@
+package gravatar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestURL(t *testing.T) {
+	// Known MD5: md5("test@example.com") = 55502f40dc8b7c769880b10874abc9d0
+	got := URL("test@example.com", 80)
+	assert.Equal(t, "https://gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=80&d=404", got)
+}
+
+func TestURL_TrimsAndLowercases(t *testing.T) {
+	a := URL("  Test@Example.COM  ", 200)
+	b := URL("test@example.com", 200)
+	assert.Equal(t, b, a)
+}
+
+func TestURL_DifferentSizes(t *testing.T) {
+	url40 := URL("user@example.com", 40)
+	url200 := URL("user@example.com", 200)
+	assert.Contains(t, url40, "s=40")
+	assert.Contains(t, url200, "s=200")
+}

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -537,6 +537,21 @@ func TestUpdateProfile_ValidationError(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
+func TestUpdateProfile_UseGravatar(t *testing.T) {
+	repo := newMockUserRepo()
+	repo.users["user1"] = &model.User{UID: "user1", Email: "a@b.com"}
+	h := NewProfileHandler(service.NewUserService(repo))
+
+	body := jsonBody(map[string]interface{}{"useGravatar": true})
+	req := httptest.NewRequest(http.MethodPut, "/api/profile", body)
+	req = withUser(req, "user1", "a@b.com")
+	rr := httptest.NewRecorder()
+	h.UpdateProfile(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "updated")
+}
+
 func TestClaimUsername_Success(t *testing.T) {
 	repo := newMockUserRepo()
 	repo.users["user1"] = &model.User{UID: "user1", Email: "a@b.com"}

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -113,6 +113,17 @@ func TestSecurityHeaders_HSTSInProduction(t *testing.T) {
 	assert.Contains(t, rr.Header().Get("Strict-Transport-Security"), "max-age=63072000")
 }
 
+func TestSecurityHeaders_CSPIncludesGravatar(t *testing.T) {
+	handler := SecurityHeaders("production")(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	csp := rr.Header().Get("Content-Security-Policy")
+	assert.Contains(t, csp, "https://gravatar.com")
+}
+
 // --- RateLimiter tests ---
 
 func TestRateLimiter_Close(t *testing.T) {

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -62,7 +62,7 @@ func buildCSP(env string) string {
 		"script-src " + scriptSrc + "; " +
 		"style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com https://unpkg.com; " +
 		"font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; " +
-		"img-src 'self' data: blob:; " +
+		"img-src 'self' data: blob: https://gravatar.com; " +
 		"connect-src " + connectSrc + "; " +
 		"frame-src https://*.firebaseapp.com; " +
 		"object-src 'none'; " +

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -323,6 +323,7 @@ func TestUserUpdate_ToUpdateMap_AllFields(t *testing.T) {
 	ig := "alice_art"
 	hbar := "0.0.12345"
 
+	useGravatar := true
 	update := &UserUpdate{
 		DisplayName:     &name,
 		Bio:             &bio,
@@ -333,6 +334,7 @@ func TestUserUpdate_ToUpdateMap_AllFields(t *testing.T) {
 		BlueskyHandle:   &bs,
 		InstagramHandle: &ig,
 		HbarAddress:     &hbar,
+		UseGravatar:     &useGravatar,
 	}
 	m := update.ToUpdateMap()
 	assert.Equal(t, "Alice", m["displayName"])
@@ -344,7 +346,22 @@ func TestUserUpdate_ToUpdateMap_AllFields(t *testing.T) {
 	assert.Equal(t, "alice.bsky.social", m["blueskyHandle"])
 	assert.Equal(t, "alice_art", m["instagramHandle"])
 	assert.Equal(t, "0.0.12345", m["hbarAddress"])
+	assert.Equal(t, true, m["useGravatar"])
 	assert.Contains(t, m, "updatedAt")
+}
+
+func TestUserUpdate_ToUpdateMap_UseGravatar_False(t *testing.T) {
+	useGravatar := false
+	update := &UserUpdate{UseGravatar: &useGravatar}
+	m := update.ToUpdateMap()
+	assert.Equal(t, false, m["useGravatar"])
+	assert.Contains(t, m, "updatedAt")
+}
+
+func TestUserUpdate_ToUpdateMap_UseGravatar_Nil(t *testing.T) {
+	update := &UserUpdate{}
+	m := update.ToUpdateMap()
+	assert.NotContains(t, m, "useGravatar")
 }
 
 // --- validateURL tests ---

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -25,6 +25,7 @@ type User struct {
 	BlueskyHandle   string    `firestore:"blueskyHandle,omitempty" json:"blueskyHandle,omitempty"`
 	InstagramHandle string    `firestore:"instagramHandle,omitempty" json:"instagramHandle,omitempty"`
 	HbarAddress     string    `firestore:"hbarAddress,omitempty" json:"hbarAddress,omitempty"`
+	UseGravatar     bool      `firestore:"useGravatar" json:"useGravatar"`
 	CreatedAt       time.Time `firestore:"createdAt" json:"createdAt"`
 	UpdatedAt       time.Time `firestore:"updatedAt" json:"updatedAt"`
 }
@@ -41,6 +42,7 @@ type UserUpdate struct {
 	BlueskyHandle   *string `firestore:"blueskyHandle,omitempty" json:"blueskyHandle,omitempty"`
 	InstagramHandle *string `firestore:"instagramHandle,omitempty" json:"instagramHandle,omitempty"`
 	HbarAddress     *string `firestore:"hbarAddress,omitempty" json:"hbarAddress,omitempty"`
+	UseGravatar     *bool   `firestore:"useGravatar,omitempty" json:"useGravatar,omitempty"`
 }
 
 // Validate checks that the User struct has required fields and valid formats.
@@ -119,6 +121,9 @@ func (u *UserUpdate) ToUpdateMap() map[string]interface{} {
 	}
 	if u.HbarAddress != nil {
 		m["hbarAddress"] = *u.HbarAddress
+	}
+	if u.UseGravatar != nil {
+		m["useGravatar"] = *u.UseGravatar
 	}
 	m["updatedAt"] = time.Now()
 	return m

--- a/web/static/styles/profile.css
+++ b/web/static/styles/profile.css
@@ -666,6 +666,42 @@ body {
     gap: 0.5rem;
 }
 
+.form-group-toggle {
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.toggle-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.toggle-label input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--primary-color);
+    cursor: pointer;
+}
+
+.form-hint {
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 0.8rem;
+    padding-left: 1.75rem;
+}
+
+.form-hint a {
+    color: var(--primary-color);
+    text-decoration: underline;
+    font-weight: 600;
+}
+
+.form-hint a:hover {
+    color: #ffffff;
+}
+
 .form-group label {
     color: var(--text-color);
     font-weight: 500;

--- a/web/templates/pages/profile.html
+++ b/web/templates/pages/profile.html
@@ -145,6 +145,13 @@
             <form id="editProfileForm" class="profile-form" method="POST" action="javascript:void(0)">
                 <div class="form-section">
                     <h3>Basic Information</h3>
+                    <div class="form-group form-group-toggle">
+                        <label for="useGravatar" class="toggle-label">
+                            <input type="checkbox" id="useGravatar" name="useGravatar">
+                            <span>Use Gravatar for profile picture</span>
+                        </label>
+                        <small class="form-hint">Uses the avatar linked to your email on <a href="https://gravatar.com" target="_blank" rel="noopener noreferrer">gravatar.com</a></small>
+                    </div>
                     <div class="form-group">
                         <label for="displayName">Display Name</label>
                         <input type="text" id="displayName" name="displayName" placeholder="Your display name">

--- a/web/ts/profile/profile.ts
+++ b/web/ts/profile/profile.ts
@@ -9,6 +9,7 @@ import {
   signOut,
 } from "../shared/firebase-init";
 import { showSuccess, showError, bindUnderConstruction } from "../shared/toast";
+import { applyProfileImage, DEFAULT_PROFILE_IMAGE } from "../shared/gravatar";
 import {
   doc,
   setDoc,
@@ -41,6 +42,7 @@ interface ProfileData {
   blueskyHandle?: string;
   instagramHandle?: string;
   hbarAddress?: string;
+  useGravatar?: boolean;
   createdAt?: Date;
   updatedAt?: Date;
   [key: string]: unknown;
@@ -475,6 +477,7 @@ async function handleProfileFormSubmit(event: Event): Promise<void> {
   }
 
   const formData = new FormData(event.target as HTMLFormElement);
+  const useGravatarCheckbox = document.getElementById("useGravatar") as HTMLInputElement | null;
   const updates: Record<string, unknown> = {
     displayName: formData.get("displayName") || "",
     bio: formData.get("bio") || "",
@@ -485,6 +488,7 @@ async function handleProfileFormSubmit(event: Event): Promise<void> {
     blueskyHandle: formData.get("blueskyHandle") || "",
     instagramHandle: formData.get("instagramHandle") || "",
     hbarAddress: formData.get("hbarAddress") || "",
+    useGravatar: useGravatarCheckbox?.checked ?? false,
     updatedAt: new Date(),
   };
 
@@ -622,6 +626,18 @@ function setupStatsListeners(uid: string): void {
 // ---- UI update functions ----
 
 function updateProfileUI(userData: ProfileData): void {
+  // Apply Gravatar or default to profile picture and nav pic
+  const useGravatar = userData.useGravatar === true;
+  const email = userData.email || auth.currentUser?.email || "";
+  const profilePic = document.getElementById("profilePicture") as HTMLImageElement | null;
+  if (profilePic) {
+    applyProfileImage(profilePic, email, useGravatar, 200);
+  }
+  const navPic = document.querySelector(".nav-profile-pic") as HTMLImageElement | null;
+  if (navPic) {
+    applyProfileImage(navPic, email, useGravatar, 80);
+  }
+
   const usernameEl = document.getElementById("profileUsername");
   if (usernameEl) {
     usernameEl.textContent = userData.username || "Choose a username";
@@ -788,6 +804,11 @@ function populateFormData(userData: ProfileData | DocumentData): void {
     "#hbarAddress",
   ) as HTMLInputElement | null;
   if (hbarInput) hbarInput.value = (userData.hbarAddress as string) || "";
+
+  const gravatarInput = form.querySelector(
+    "#useGravatar",
+  ) as HTMLInputElement | null;
+  if (gravatarInput) gravatarInput.checked = userData.useGravatar === true;
 }
 
 function populateFormFromUI(): void {

--- a/web/ts/shared/gravatar.ts
+++ b/web/ts/shared/gravatar.ts
@@ -1,0 +1,135 @@
+// ============================================================
+// Gravatar URL helper — computes MD5-based Gravatar URLs
+// ============================================================
+
+/**
+ * Computes the Gravatar URL for a given email address.
+ * Uses d=404 so the caller can detect missing avatars via onerror.
+ */
+export async function gravatarUrl(
+  email: string,
+  size: number = 80,
+): Promise<string> {
+  const normalized = email.trim().toLowerCase();
+  const hash = await md5Hex(normalized);
+  return `https://gravatar.com/avatar/${hash}?s=${size}&d=404`;
+}
+
+/** Default profile image path. */
+export const DEFAULT_PROFILE_IMAGE = "/static/images/panda.png";
+
+/**
+ * Sets the src of an <img> element to the Gravatar URL if useGravatar is true,
+ * otherwise uses the default. Adds an onerror fallback either way.
+ */
+export async function applyProfileImage(
+  img: HTMLImageElement,
+  email: string | undefined,
+  useGravatar: boolean,
+  size: number = 80,
+): Promise<void> {
+  img.onerror = function (this: HTMLImageElement) {
+    this.onerror = null;
+    this.src = DEFAULT_PROFILE_IMAGE;
+  };
+
+  if (useGravatar && email) {
+    img.src = await gravatarUrl(email, size);
+  } else {
+    img.src = DEFAULT_PROFILE_IMAGE;
+  }
+}
+
+// ---- MD5 implementation using SubtleCrypto ----
+
+async function md5Hex(input: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(input);
+  // SubtleCrypto doesn't support MD5, so we use a minimal pure-JS MD5.
+  return md5(data);
+}
+
+// Minimal MD5 implementation (RFC 1321) for Gravatar hashing only.
+// This avoids pulling in a dependency for a single use case.
+function md5(bytes: Uint8Array): string {
+  const K = new Uint32Array([
+    0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a,
+    0xa8304613, 0xfd469501, 0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be,
+    0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821, 0xf61e2562, 0xc040b340,
+    0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+    0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed, 0xa9e3e905, 0xfcefa3f8,
+    0x676f02d9, 0x8d2a4c8a, 0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c,
+    0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70, 0x289b7ec6, 0xeaa127fa,
+    0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+    0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92,
+    0xffeff47d, 0x85845dd1, 0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1,
+    0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
+  ]);
+  const S = [
+    7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 5, 9, 14, 20,
+    5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 4, 11, 16, 23, 4, 11, 16, 23,
+    4, 11, 16, 23, 4, 11, 16, 23, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21,
+    6, 10, 15, 21,
+  ];
+
+  // Pre-processing: pad message
+  const bitLen = bytes.length * 8;
+  const padLen = (bytes.length % 64 < 56 ? 56 : 120) - (bytes.length % 64);
+  const padded = new Uint8Array(bytes.length + padLen + 8);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  const view = new DataView(padded.buffer);
+  view.setUint32(padded.length - 8, bitLen >>> 0, true);
+  view.setUint32(padded.length - 4, Math.floor(bitLen / 0x100000000), true);
+
+  let a0 = 0x67452301 >>> 0;
+  let b0 = 0xefcdab89 >>> 0;
+  let c0 = 0x98badcfe >>> 0;
+  let d0 = 0x10325476 >>> 0;
+
+  for (let i = 0; i < padded.length; i += 64) {
+    const M = new Uint32Array(16);
+    for (let j = 0; j < 16; j++) {
+      M[j] = view.getUint32(i + j * 4, true);
+    }
+
+    let A = a0,
+      B = b0,
+      C = c0,
+      D = d0;
+
+    for (let j = 0; j < 64; j++) {
+      let F: number, g: number;
+      if (j < 16) {
+        F = (B & C) | (~B & D);
+        g = j;
+      } else if (j < 32) {
+        F = (D & B) | (~D & C);
+        g = (5 * j + 1) % 16;
+      } else if (j < 48) {
+        F = B ^ C ^ D;
+        g = (3 * j + 5) % 16;
+      } else {
+        F = C ^ (B | ~D);
+        g = (7 * j) % 16;
+      }
+      F = (F + A + K[j] + M[g]) >>> 0;
+      A = D;
+      D = C;
+      C = B;
+      B = (B + ((F << S[j]) | (F >>> (32 - S[j])))) >>> 0;
+    }
+
+    a0 = (a0 + A) >>> 0;
+    b0 = (b0 + B) >>> 0;
+    c0 = (c0 + C) >>> 0;
+    d0 = (d0 + D) >>> 0;
+  }
+
+  function toHex(n: number): string {
+    const bytes = [n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff];
+    return bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+  }
+
+  return toHex(a0) + toHex(b0) + toHex(c0) + toHex(d0);
+}

--- a/web/ts/shared/types.ts
+++ b/web/ts/shared/types.ts
@@ -41,6 +41,9 @@ export interface User {
   // Blockchain
   hbarAddress?: string;
 
+  // Gravatar
+  useGravatar?: boolean;
+
   // Timestamps
   createdAt: Date;
   updatedAt: Date;
@@ -57,6 +60,7 @@ export interface UserUpdate {
   twitterHandle?: string;
   blueskyHandle?: string;
   hbarAddress?: string;
+  useGravatar?: boolean;
 }
 
 /** Canvas configuration options */


### PR DESCRIPTION
## Description

This pull request introduces Gravatar profile picture support, allow users to use their Gravatar avatar as their profile image throughout the application. It adds a `useGravatar` boolean field to user profiles, updates the database schema and API documentation, implements Gravatar URL helpers in both backend and frontend, and ensures proper UI integration and security policy updates. The most important changes are grouped below:

**Backend: Gravatar Support & Data Model Updates**

* Added a `useGravatar` boolean field to the `User` and `UserUpdate` structs in `internal/model/user.go`, updated the `ToUpdateMap` method, and extended tests to cover this field. [[1]](diffhunk://#diff-fb3cdc2f0ac0aadfb614ed70de57060a4687801fc2f9d65dc23a32c8ebb7a8beR28) [[2]](diffhunk://#diff-fb3cdc2f0ac0aadfb614ed70de57060a4687801fc2f9d65dc23a32c8ebb7a8beR45) [[3]](diffhunk://#diff-fb3cdc2f0ac0aadfb614ed70de57060a4687801fc2f9d65dc23a32c8ebb7a8beR125-R127) [[4]](diffhunk://#diff-76170cd7afadb06903c34c4d56eb6ba401252aed281ef1d56ea1fea4fe8cf2e2R326) [[5]](diffhunk://#diff-76170cd7afadb06903c34c4d56eb6ba401252aed281ef1d56ea1fea4fe8cf2e2R337) [[6]](diffhunk://#diff-76170cd7afadb06903c34c4d56eb6ba401252aed281ef1d56ea1fea4fe8cf2e2R349-R366)
* Created a new `internal/gravatar/gravatar.go` helper to generate Gravatar URLs, along with comprehensive unit tests. [[1]](diffhunk://#diff-7e0a2a063afe114583007d499fbedd894496baee3e2505ac2ab4eaa3aeb1617eR1-R16) [[2]](diffhunk://#diff-99423ea929bcc5e599f7408bae1f7268ab502e9406c2796dee44f9399d9e8963R1-R26)

**API & Documentation**

* Updated the OpenAPI spec (`api/openapi.yaml`) and database schema docs to include the `useGravatar` field, with descriptions and example usage. [[1]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R617-R619) [[2]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R654-R656) [[3]](diffhunk://#diff-2cb2c2e30373bd9a6fd3890e6115c05e995e5bf146363e70be312819e7f22b63R41) [[4]](diffhunk://#diff-2cb2c2e30373bd9a6fd3890e6115c05e995e5bf146363e70be312819e7f22b63R66)
* Updated the project structure documentation to reflect the new Gravatar helper modules in both backend and frontend. [[1]](diffhunk://#diff-f4f155ac59b8fed51a3f98e2341308b2635b8096ba3a56a94531205f84257af9R43-R46) [[2]](diffhunk://#diff-f4f155ac59b8fed51a3f98e2341308b2635b8096ba3a56a94531205f84257af9L105-R110)

**Frontend: UI and Logic Integration**

* Added a toggle in the profile edit form (`profile.html`, `profile.css`) for users to enable/disable Gravatar, and updated form handling logic to persist this preference. [[1]](diffhunk://#diff-bb39a7dff828816fe29c97cc0b83d7ca836632e6763e81ab6d0bf6ae9d896d73R148-R154) [[2]](diffhunk://#diff-bc104ce33490db5ddcd256317e7604936dd989b6e531b21e51ccd9b2b9d8e6f6R669-R704) [[3]](diffhunk://#diff-595176c3331c11f20c48a22faf547bee3dd6c5fc38a9401a36a60276a2cbd599R45) [[4]](diffhunk://#diff-595176c3331c11f20c48a22faf547bee3dd6c5fc38a9401a36a60276a2cbd599R480) [[5]](diffhunk://#diff-595176c3331c11f20c48a22faf547bee3dd6c5fc38a9401a36a60276a2cbd599R491) [[6]](diffhunk://#diff-595176c3331c11f20c48a22faf547bee3dd6c5fc38a9401a36a60276a2cbd599R807-R811)
* Implemented Gravatar image application logic in the frontend (`gravatar.ts`), ensuring profile and navigation images use Gravatar when enabled. Updated relevant TypeScript files to use this logic and listen for profile changes. [[1]](diffhunk://#diff-595176c3331c11f20c48a22faf547bee3dd6c5fc38a9401a36a60276a2cbd599R12) [[2]](diffhunk://#diff-595176c3331c11f20c48a22faf547bee3dd6c5fc38a9401a36a60276a2cbd599R629-R640) [[3]](diffhunk://#diff-bc20a137455bea71ed71d7faf938ba3544ec9a2311e59d11ced45d62876984afR7-R10) [[4]](diffhunk://#diff-bc20a137455bea71ed71d7faf938ba3544ec9a2311e59d11ced45d62876984afR37) [[5]](diffhunk://#diff-bc20a137455bea71ed71d7faf938ba3544ec9a2311e59d11ced45d62876984afR102-R104) [[6]](diffhunk://#diff-bc20a137455bea71ed71d7faf938ba3544ec9a2311e59d11ced45d62876984afR282-R306)

**Security and Policy**

* Updated the Content Security Policy (CSP) to allow images from `https://gravatar.com` and added corresponding tests to ensure the policy is enforced. [[1]](diffhunk://#diff-8ebb4f4a1148e148463551565a5493cef69861a4ff531bcb6cab6bc270674a41L65-R65) [[2]](diffhunk://#diff-26c937ff280cadd71c27d16e6f124c8ef9eec97b3da0d810f260c8dc4f9aa4dbR116-R126)

**Testing**

* Added/updated tests for profile update handling, model changes, Gravatar URL generation, and CSP enforcement to ensure robust coverage of new functionality. [[1]](diffhunk://#diff-3989575fa41b8a0d58d99e7fd537ec1ce4f054c6014488c21d8909daf6fdf011R540-R554) [[2]](diffhunk://#diff-76170cd7afadb06903c34c4d56eb6ba401252aed281ef1d56ea1fea4fe8cf2e2R326) [[3]](diffhunk://#diff-76170cd7afadb06903c34c4d56eb6ba401252aed281ef1d56ea1fea4fe8cf2e2R337) [[4]](diffhunk://#diff-76170cd7afadb06903c34c4d56eb6ba401252aed281ef1d56ea1fea4fe8cf2e2R349-R366) [[5]](diffhunk://#diff-99423ea929bcc5e599f7408bae1f7268ab502e9406c2796dee44f9399d9e8963R1-R26) [[6]](diffhunk://#diff-26c937ff280cadd71c27d16e6f124c8ef9eec97b3da0d810f260c8dc4f9aa4dbR116-R126)

## Related Issue(s)

- Closes #104